### PR TITLE
The website is now live at pentest.m14r41.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A complete, searchable penetration-testing knowledge base across 23 security domains.**
 
-### 🌐 Live website: **[pentest.m14r41.in](https://pentest.m14r41.in)**
+### Live website: **[pentest.m14r41.in](https://pentest.m14r41.in)**
 
 [Live Website](https://pentest.m14r41.in) · [PentestingChecklist](https://checklist.m14r41.in) · [Contribute](https://github.com/m14r41/PentestingEverything/blob/main/CONTRIBUTING.md) · [Report an Issue](https://github.com/m14r41/PentestingEverything/issues)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 > Read it online at **[pentest.m14r41.in](https://pentest.m14r41.in)**: fully searchable, with 108 documentation pages, 104 reference PDFs, and 212+ topics across 23 domains. The website turns this repository into a fast, structured, and readable knowledge base.
 
+> New in v2.0.0: the project is now a full website with instant full-text search, a filterable reference PDF library, learning paths for common engagements, and a companion checklist at [checklist.m14r41.in](https://checklist.m14r41.in). Full notes in the [changelog](CHANGELOG.md).
+
 **[PentestingEverything](https://pentest.m14r41.in/)** is an open-source, comprehensive penetration-testing knowledge base. It brings together methodology, checklists, payloads, commands, and field-tested references across 23 domains: web, API, mobile, network, cloud, Active Directory, OSINT, and more. The goal is simple: give you the concise, practical knowledge to assess any target, from scoping an engagement to hunting a specific vulnerability class to writing the report.
 
 > **Practical companion: [PentestingChecklist](https://checklist.m14r41.in/).** This project is the knowledge base. The checklist is the hands-on, tick-as-you-go companion. A structured checklist across 23 platforms (web, API, mobile, cloud, AD and more) with progress tracking, notes, and export. Use them side by side.


### PR DESCRIPTION
## The website is now live: https://pentest.m14r41.in

PentestingEverything has moved from a GitHub repository of markdown folders to a fast, searchable website. Pentesters can now get help quickly during a real engagement instead of scrolling raw files.

### What pentesters get on the site

- Instant full-text search across everything (Ctrl/Cmd + K), fully offline-capable, no external service
- A reference library with all 104 PDFs, grouped by domain, with filter, open, and download
- Learning paths for common engagements: web, cloud, mobile, red team, AI/LLM, and DevSecOps
- Reading-first pages: clean typography, dark and light themes, breadcrumbs, and a table of contents
- 108 documentation pages and 212+ topics across 23 security domains
- A companion checklist at https://checklist.m14r41.in to track findings during an engagement

### What this PR changes

- Announces the live website in the README so anyone landing on the repository finds it immediately
- Keeps the header plain and professional (no decorative icons)
- Points to the full v2.0.0 changelog

Live now: https://pentest.m14r41.in
